### PR TITLE
Refactor XML index helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 
 # Ignorar todos los archivos .pyc y .pyo por si acaso
 *.py[cod]
+venv/

--- a/flows/scrape_boe_day_metadata.py
+++ b/flows/scrape_boe_day_metadata.py
@@ -1,6 +1,10 @@
 from prefect import flow
 from tasks.storage import append_metadata
-from tasks.boe import fetch_boes_from_data, extract_article_ids, get_article_metadata
+from tasks.boe import (
+    fetch_index_xml,
+    extract_article_ids,
+    get_article_metadata,
+)
 
 
 @flow
@@ -11,7 +15,7 @@ def scrape_boe_day_metadata(url_date_str: str = "2025/07/03"):
         raise ValueError("url_date_str must be in YYYY/MM/DD format")
     year, month, day = parts[0], parts[1], parts[2]
 
-    index_boes = fetch_boes_from_data(year, month, day)
+    index_boes = fetch_index_xml(year, month, day)
     boe_ids = extract_article_ids(index_boes)
 
     # Reconstruct fecha in YYYY-MM-DD format for get_article_metadata


### PR DESCRIPTION
## Summary
- encapsulate date parsing and sumario URL building
- validate XML content type in `fetch_index_xml`
- update tests for new behavior

## Testing
- `pytest -q` *(fails: error: unrecognized arguments: --cov=tasks --cov=flows --cov-report=term-missing --cov-report=xml)*

------
https://chatgpt.com/codex/tasks/task_e_6867e42b3550832da9d0c2d78fd822d7