### PR TITLE
Add SQLite database support

### DIFF
--- a/tasks/database.py
+++ b/tasks/database.py
@@ -1,0 +1,74 @@
+from prefect import task
+import sqlite3
+from pathlib import Path
+
+@task
+def init_db(db_path: str = "data/boe.db"):
+    """Create SQLite database and required tables if they do not exist."""
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS metadata (
+            id TEXT PRIMARY KEY,
+            date TEXT,
+            title TEXT,
+            department TEXT,
+            rank TEXT,
+            url_xml TEXT,
+            url_pdf TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS articles (
+            id TEXT PRIMARY KEY,
+            date TEXT,
+            title TEXT,
+            department TEXT,
+            rank TEXT,
+            text TEXT,
+            url_xml TEXT,
+            url_pdf TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+@task
+def insert_article(record: dict, text: str, db_path: str = "data/boe.db"):
+    """Insert or replace article metadata and text into the database."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    meta_values = (
+        record.get("id"),
+        record.get("date"),
+        record.get("title"),
+        record.get("department"),
+        record.get("rank"),
+        record.get("url_xml"),
+        record.get("url_pdf"),
+    )
+    cur.execute(
+        """
+        INSERT OR REPLACE INTO metadata (
+            id, date, title, department, rank, url_xml, url_pdf
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        meta_values,
+    )
+    article_values = meta_values[:5] + (text,) + meta_values[5:]
+    cur.execute(
+        """
+        INSERT OR REPLACE INTO articles (
+            id, date, title, department, rank, text, url_xml, url_pdf
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        article_values,
+    )
+    conn.commit()
+    conn.close()

--- a/tests/tasks/test_database.py
+++ b/tests/tasks/test_database.py
@@ -1,0 +1,50 @@
+import sqlite3
+import tempfile
+from pathlib import Path
+from tasks.database import init_db, insert_article
+
+
+def test_init_db_creates_tables():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "test.db"
+        init_db.fn(str(db_file))
+        conn = sqlite3.connect(db_file)
+        cur = conn.cursor()
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in cur.fetchall()}
+        conn.close()
+        assert "articles" in tables
+        assert "metadata" in tables
+
+
+def test_insert_article_and_replace():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "test.db"
+        init_db.fn(str(db_file))
+        record = {
+            "id": "1",
+            "date": "2023-01-01",
+            "title": "Title",
+            "department": "Dept",
+            "rank": "Rank",
+            "url_xml": "xml",
+            "url_pdf": "pdf",
+        }
+        insert_article.fn(record, "Text", str(db_file))
+        conn = sqlite3.connect(db_file)
+        cur = conn.cursor()
+        cur.execute("SELECT text FROM articles WHERE id=?", ("1",))
+        first_text = cur.fetchone()[0]
+        assert first_text == "Text"
+        cur.execute("SELECT count(*) FROM metadata")
+        assert cur.fetchone()[0] == 1
+        # Replace with new data
+        record["title"] = "New"  # modify field to verify replace
+        insert_article.fn(record, "New Text", str(db_file))
+        cur.execute("SELECT title, text FROM articles WHERE id=?", ("1",))
+        title, new_text = cur.fetchone()
+        assert title == "New"
+        assert new_text == "New Text"
+        cur.execute("SELECT count(*) FROM articles")
+        assert cur.fetchone()[0] == 1
+        conn.close()


### PR DESCRIPTION
## Summary
- implement `init_db` and `insert_article` to manage SQLite data
- create tests for database utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b864a0a4c832dba043f38a052f8e7