### PR TITLE
Add SQLite handling to BOE scraping flow

### DIFF
--- a/tasks/database.py
+++ b/tasks/database.py
@@ -2,6 +2,7 @@ from prefect import task
 import sqlite3
 from pathlib import Path
 
+
 @task
 def init_db(db_path: str = "data/boe.db"):
     """Create SQLite database and required tables if they do not exist."""
@@ -39,6 +40,7 @@ def init_db(db_path: str = "data/boe.db"):
     conn.commit()
     conn.close()
 
+
 @task
 def insert_article(record: dict, text: str, db_path: str = "data/boe.db"):
     """Insert or replace article metadata and text into the database."""
@@ -72,3 +74,14 @@ def insert_article(record: dict, text: str, db_path: str = "data/boe.db"):
     )
     conn.commit()
     conn.close()
+
+
+@task
+def article_exists(boe_id: str, db_path: str = "data/boe.db") -> bool:
+    """Check if an article already exists in the database."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT 1 FROM articles WHERE id=?", (boe_id,))
+    exists = cur.fetchone() is not None
+    conn.close()
+    return exists

--- a/tests/flows/test_scrape_boe_day_metadata.py
+++ b/tests/flows/test_scrape_boe_day_metadata.py
@@ -2,23 +2,31 @@ import pytest
 from unittest.mock import patch
 from flows.scrape_boe_day_metadata import scrape_boe_day_metadata
 
-from unittest.mock import call # Import call for checking multiple calls
+from unittest.mock import call  # Import call for checking multiple calls
 from prefect.testing.utilities import prefect_test_harness
 
-@patch('flows.scrape_boe_day_metadata.append_metadata')
-@patch('flows.scrape_boe_day_metadata.get_article_metadata')
-@patch('flows.scrape_boe_day_metadata.extract_article_ids')
-@patch('flows.scrape_boe_day_metadata.fetch_index_xml')
+
+@patch("flows.scrape_boe_day_metadata.insert_article")
+@patch("flows.scrape_boe_day_metadata.parse_article_xml")
+@patch("flows.scrape_boe_day_metadata.fetch_article_xml")
+@patch("flows.scrape_boe_day_metadata.article_exists")
+@patch("flows.scrape_boe_day_metadata.append_metadata")
+@patch("flows.scrape_boe_day_metadata.get_article_metadata")
+@patch("flows.scrape_boe_day_metadata.extract_article_ids")
+@patch("flows.scrape_boe_day_metadata.fetch_index_xml")
 def test_scrape_boe_day_metadata_flow(
     mock_fetch_index_xml,
     mock_extract_article_ids,
     mock_get_article_metadata,
-    mock_append_metadata
+    mock_append_metadata,
+    mock_article_exists,
+    mock_fetch_article_xml,
+    mock_parse_article_xml,
+    mock_insert_article,
 ):
     test_url_date_str = "2023/01/01"
     expected_year, expected_month, expected_day = "2023", "01", "01"
     expected_date_iso = "2023-01-01"
-
 
     # Configure mocks
     mock_fetch_index_xml.return_value = "<xml>dummy index</xml>"
@@ -27,54 +35,97 @@ def test_scrape_boe_day_metadata_flow(
     # Mock metadata returned for each ID
     mock_get_article_metadata.side_effect = [
         {"id": "ID-1", "data": "meta1"},
-        {"id": "ID-2", "data": "meta2"}
+        {"id": "ID-2", "data": "meta2"},
+    ]
+
+    mock_article_exists.side_effect = [False, False]
+    mock_fetch_article_xml.side_effect = ["<xml>1</xml>", "<xml>2</xml>"]
+    mock_parse_article_xml.side_effect = [
+        {"title": "t1", "department": "d1", "rank": "r1", "text": "txt1"},
+        {"title": "t2", "department": "d2", "rank": "r2", "text": "txt2"},
     ]
 
     # Call the flow's function directly
     scrape_boe_day_metadata.fn(url_date_str=test_url_date_str)
 
     # Assertions
-    mock_fetch_index_xml.assert_called_once_with(expected_year, expected_month, expected_day)
+    mock_fetch_index_xml.assert_called_once_with(
+        expected_year, expected_month, expected_day
+    )
     mock_extract_article_ids.assert_called_once_with("<xml>dummy index</xml>")
 
     # Check calls to get_article_metadata
     expected_get_metadata_calls = [
         call("ID-1", expected_date_iso),
-        call("ID-2", expected_date_iso)
+        call("ID-2", expected_date_iso),
     ]
-    mock_get_article_metadata.assert_has_calls(expected_get_metadata_calls, any_order=False)
+    mock_get_article_metadata.assert_has_calls(
+        expected_get_metadata_calls, any_order=False
+    )
     assert mock_get_article_metadata.call_count == 2
+
+    # Check existence check and XML processing
+    expected_exists_calls = [call("ID-1"), call("ID-2")]
+    mock_article_exists.assert_has_calls(expected_exists_calls, any_order=False)
+    assert mock_article_exists.call_count == 2
+
+    mock_fetch_article_xml.assert_has_calls(
+        [call("ID-1"), call("ID-2")], any_order=False
+    )
+    assert mock_fetch_article_xml.call_count == 2
+
+    mock_parse_article_xml.assert_has_calls(
+        [call("<xml>1</xml>"), call("<xml>2</xml>")], any_order=False
+    )
+    assert mock_parse_article_xml.call_count == 2
+
+    assert mock_insert_article.call_count == 2
 
     # Check calls to append_metadata
     expected_append_calls = [
         call({"id": "ID-1", "data": "meta1"}),
-        call({"id": "ID-2", "data": "meta2"})
+        call({"id": "ID-2", "data": "meta2"}),
     ]
     mock_append_metadata.assert_has_calls(expected_append_calls, any_order=False)
     assert mock_append_metadata.call_count == 2
 
-@patch('flows.scrape_boe_day_metadata.append_metadata')
-@patch('flows.scrape_boe_day_metadata.get_article_metadata')
-@patch('flows.scrape_boe_day_metadata.extract_article_ids')
-@patch('flows.scrape_boe_day_metadata.fetch_index_xml')
+
+@patch("flows.scrape_boe_day_metadata.insert_article")
+@patch("flows.scrape_boe_day_metadata.parse_article_xml")
+@patch("flows.scrape_boe_day_metadata.fetch_article_xml")
+@patch("flows.scrape_boe_day_metadata.article_exists")
+@patch("flows.scrape_boe_day_metadata.append_metadata")
+@patch("flows.scrape_boe_day_metadata.get_article_metadata")
+@patch("flows.scrape_boe_day_metadata.extract_article_ids")
+@patch("flows.scrape_boe_day_metadata.fetch_index_xml")
 def test_scrape_boe_day_metadata_flow_no_ids(
     mock_fetch_index_xml,
     mock_extract_article_ids,
     mock_get_article_metadata,
-    mock_append_metadata
+    mock_append_metadata,
+    mock_article_exists,
+    mock_fetch_article_xml,
+    mock_parse_article_xml,
+    mock_insert_article,
 ):
     test_url_date_str = "2023/01/02"
     expected_year, expected_month, expected_day = "2023", "01", "02"
     # expected_date_iso is not used here as get_article_metadata should not be called
 
     mock_fetch_index_xml.return_value = "<xml>empty index</xml>"
-    mock_extract_article_ids.return_value = [] # No IDs found
+    mock_extract_article_ids.return_value = []  # No IDs found
 
     scrape_boe_day_metadata.fn(url_date_str=test_url_date_str)
 
-    mock_fetch_index_xml.assert_called_once_with(expected_year, expected_month, expected_day)
+    mock_fetch_index_xml.assert_called_once_with(
+        expected_year, expected_month, expected_day
+    )
     mock_extract_article_ids.assert_called_once_with("<xml>empty index</xml>")
 
     # Ensure these were NOT called if no IDs
     mock_get_article_metadata.assert_not_called()
     mock_append_metadata.assert_not_called()
+    mock_article_exists.assert_not_called()
+    mock_fetch_article_xml.assert_not_called()
+    mock_parse_article_xml.assert_not_called()
+    mock_insert_article.assert_not_called()


### PR DESCRIPTION
## Summary
- load BOE articles to SQLite instead of jsonl
- add helpers to fetch and parse article XML
- check for existing records before scraping
- update unit tests for the new behaviour

## Testing
- `venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b89f429c8832d8522626543e9290b