### PR TITLE
Switch to XML parsing for BOE ID extraction

### DIFF
--- a/tasks/boe.py
+++ b/tasks/boe.py
@@ -62,9 +62,16 @@ def fetch_index_xml_by_date(date_str: str) -> str:
 
 @task
 def extract_article_ids(index_xml: str) -> list[str]:
-    # Extract BOE-A-XXXX-YYYY using regex
-    ids = re.findall(r"BOE-A-\d{4}-\d{5}", index_xml)
-    return list(set(ids))  # avoid duplicates
+    """Return unique article IDs from the daily index XML."""
+
+    root = ET.fromstring(index_xml)
+    ids: set[str] = set()
+    for elem in root.iter():
+        id_attr = elem.attrib.get("id")
+        if id_attr and id_attr.startswith("BOE-A-"):
+            ids.add(id_attr)
+
+    return list(ids)
 
 
 @task

--- a/tests/tasks/test_boe.py
+++ b/tests/tasks/test_boe.py
@@ -94,7 +94,9 @@ def test_extract_article_ids(capsys):
         <item id="BOE-A-2023-12345"/>
         <item id="BOE-S-2023-00123"/>
         <item id="BOE-A-2023-67890"/>
+        <other attr="BOE-A-2024-11111"/>
         <item id="BOE-A-2023-12345"/>
+        <text>BOE-A-9999-99999</text>
     </document>
     """
     expected_ids = ["BOE-A-2023-12345", "BOE-A-2023-67890"]
@@ -108,7 +110,12 @@ def test_extract_article_ids(capsys):
 
 
 def test_extract_article_ids_no_matches(capsys):
-    sample_xml_content = "<document><item id='OTHER-ID-123'/></document>"
+    sample_xml_content = """
+    <document>
+        <text>BOE-A-2025-00001</text>
+        <other attr='BOE-A-2025-00002'/>
+    </document>
+    """
     result = extract_article_ids.fn(sample_xml_content)
     print(f"Resultado de extract_article_ids_no_matches: {result}")
     assert result == []


### PR DESCRIPTION
## Summary
- parse the index XML to find article IDs instead of using regex
- return unique article IDs
- expand unit tests to ensure IDs are only taken from `id` attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb2e0de00832da69da24ef49005e8