### PR TITLE
Add detailed logging for BOE tasks

### DIFF
--- a/tasks/boe.py
+++ b/tasks/boe.py
@@ -14,48 +14,64 @@ def _parse_date_to_ymd(date_str: str) -> tuple[str, str, str]:
     removed and exactly eight digits are required.
     """
 
+    print(f"_parse_date_to_ymd -> date_str: {date_str}")
     digits = re.sub(r"\D", "", date_str)
     if len(digits) != 8:
         raise ValueError("The date must contain year, month and day (YYYYMMDD).")
 
-    return digits[:4], digits[4:6], digits[6:8]
+    year, month, day = digits[:4], digits[4:6], digits[6:8]
+    print(f"_parse_date_to_ymd -> parsed: {year}-{month}-{day}")
+    return year, month, day
 
 
 def _build_sumario_url(year: str, month: str, day: str) -> str:
     """Build the daily BOE index URL."""
 
-    return (
+    url = (
         f"{BOE_BASE}/datosabiertos/api/boe/sumario/"
         f"{year}{month.zfill(2)}{day.zfill(2)}"
     )
+    print(
+        f"_build_sumario_url -> year:{year} month:{month} day:{day} url:{url}"
+    )
+    return url
 
 
 @task
 def fetch_boes_from_data(year: str, month: str, day: str) -> str:
+    print(
+        f"fetch_boes_from_data -> params: year={year} month={month} day={day}"
+    )
     month_padded = month.zfill(2)
     day_padded = day.zfill(2)
     url = f"https://www.boe.es/boe/dias/{year}/{month_padded}/{day_padded}/"
+    print(f"fetch_boes_from_data -> url: {url}")
     r = requests.get(url)
     r.raise_for_status()
+    print("fetch_boes_from_data -> response size:", len(r.text))
     return r.text
 
 
 @task
 def fetch_index_xml(year: str, month: str, day: str) -> str:
     """Get the daily XML index given year, month and day."""
-
+    print(
+        f"fetch_index_xml -> params: year={year} month={month} day={day}"
+    )
     url = _build_sumario_url(year, month, day)
+    print(f"fetch_index_xml -> url: {url}")
     r = requests.get(url, headers={"Accept": "application/xml"})
     r.raise_for_status()
     if "xml" not in r.headers.get("Content-Type", ""):
         raise ValueError("Response is not XML")
+    print("fetch_index_xml -> response size:", len(r.text))
     return r.text
 
 
 @task
 def fetch_index_xml_by_date(date_str: str) -> str:
     """Download the XML index for a given date."""
-
+    print(f"fetch_index_xml_by_date -> date_str: {date_str}")
     year, month, day = _parse_date_to_ymd(date_str)
     return fetch_index_xml.fn(year, month, day)
 
@@ -77,7 +93,9 @@ def extract_article_ids(index_xml: str) -> list[str]:
         if elem.text:
             ids.update(pattern.findall(elem.text))
 
-    return list(ids)
+    id_list = list(ids)
+    print(f"extract_article_ids -> found {len(id_list)} ids")
+    return id_list
 
 
 @task
@@ -96,22 +114,30 @@ def get_article_metadata(boe_id: str, date_str: str) -> dict:
             f"Date format is incorrect in get_article_metadata: {date_str}. Expected YYYY-MM-DD."
         )
 
+    print(
+        f"get_article_metadata -> boe_id:{boe_id} date_str:{date_str}"
+    )
     url_xml = f"https://www.boe.es/diario_boe/xml.php?id={boe_id}"
     url_pdf = f"https://www.boe.es/boe/dias/{year}/{month.zfill(2)}/{day.zfill(2)}/pdfs/{boe_id}.pdf"
-    return {
+    metadata = {
         "id": boe_id,
         "date": date_str,  # Keep original date for metadata record
         "url_xml": url_xml,
         "url_pdf": url_pdf,
     }
+    print(f"get_article_metadata -> metadata: {metadata}")
+    return metadata
 
 
 @task
 def fetch_article_xml(boe_id: str) -> str:
     """Download the XML for a specific article."""
+    print(f"fetch_article_xml -> boe_id: {boe_id}")
     url = f"https://www.boe.es/diario_boe/xml.php?id={boe_id}"
+    print(f"fetch_article_xml -> url: {url}")
     r = requests.get(url)
     r.raise_for_status()
+    print("fetch_article_xml -> response size:", len(r.text))
     return r.text
 
 
@@ -125,24 +151,31 @@ def parse_article_xml(xml_text: str) -> dict:
     raw_text = root.findtext(".//texto") or ""
     cleaned = clean_boe_text(raw_text)
     segments = split_into_paragraphs(cleaned)
-    return {
+    data = {
         "title": title,
         "department": department,
         "rank": rank,
         "segments": segments,
     }
+    print(
+        f"parse_article_xml -> title:{title} department:{department} rank:{rank} segments:{len(segments)}"
+    )
+    return data
 
 
 @task
 def fetch_article_text(url_xml: str) -> tuple[dict, list[str]]:
     """Download an article XML and return metadata and cleaned segments."""
+    print(f"fetch_article_text -> url: {url_xml}")
     r = requests.get(url_xml)
     r.raise_for_status()
     xml_text = r.text
+    print("fetch_article_text -> downloaded", len(xml_text), "chars")
     article_data = parse_article_xml.fn(xml_text)
     metadata = {
         "title": article_data.get("title"),
         "department": article_data.get("department"),
         "rank": article_data.get("rank"),
     }
+    print(f"fetch_article_text -> metadata: {metadata}")
     return metadata, article_data.get("segments")


### PR DESCRIPTION
## Summary
- show inputs, URLs and outputs when scraping BOE data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bfda526f4832dbc4cf38b5394b2e7