### PR TITLE
Add verbose file and database output

### DIFF
--- a/tasks/database.py
+++ b/tasks/database.py
@@ -39,6 +39,8 @@ def init_db(db_path: str = "data/boe.db"):
     )
     conn.commit()
     conn.close()
+    print(f"Ruta de base de datos utilizada: {path}")
+    print("Base de datos inicializada.")
 
 
 @task
@@ -74,6 +76,8 @@ def insert_article(record: dict, text: str, db_path: str = "data/boe.db"):
     )
     conn.commit()
     conn.close()
+    print(f"Ruta de base de datos utilizada: {db_path}")
+    print("Artículo insertado correctamente.")
 
 
 @task

--- a/tasks/storage.py
+++ b/tasks/storage.py
@@ -6,7 +6,10 @@ from pathlib import Path
 @task
 def storage_text(text: str, filename: str):
     path = Path("data/raw") / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+    print(f"Ruta de archivo utilizada: {path}")
+    print("Texto almacenado correctamente.")
 
 
 @task
@@ -15,3 +18,5 @@ def append_metadata(record: dict, file_path: str = "data/boe_metadata.jsonl"):
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    print(f"Ruta de archivo utilizada: {path}")
+    print("Registro de metadata guardado correctamente.")


### PR DESCRIPTION
## Summary
- print paths and confirmation messages in storage tasks
- print database path and insertion confirmation in db tasks
- ensure `storage_text` creates `data/raw` if needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cacd77b18832dbd0f545aaa719555