### PR TITLE
Implement shared HTTP session

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,0 +1,14 @@
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+# Shared HTTP session with retries
+session = Session()
+retries = Retry(
+    total=3,
+    backoff_factor=1,
+    status_forcelist=[429, 500, 502, 503, 504],
+)
+adapter = HTTPAdapter(max_retries=retries)
+session.mount("http://", adapter)
+session.mount("https://", adapter)

--- a/tasks/boe.py
+++ b/tasks/boe.py
@@ -1,5 +1,5 @@
 from prefect import task
-import requests
+from tasks import session
 import re
 import xml.etree.ElementTree as ET
 from tasks.processing import clean_boe_text, split_into_paragraphs
@@ -46,7 +46,7 @@ def fetch_boes_from_data(year: str, month: str, day: str) -> str:
     day_padded = day.zfill(2)
     url = f"https://www.boe.es/boe/dias/{year}/{month_padded}/{day_padded}/"
     print(f"fetch_boes_from_data -> url: {url}")
-    r = requests.get(url)
+    r = session.get(url, timeout=10)
     r.raise_for_status()
     print("fetch_boes_from_data -> response size:", len(r.text))
     return r.text
@@ -60,7 +60,7 @@ def fetch_index_xml(year: str, month: str, day: str) -> str:
     )
     url = _build_sumario_url(year, month, day)
     print(f"fetch_index_xml -> url: {url}")
-    r = requests.get(url, headers={"Accept": "application/xml"})
+    r = session.get(url, headers={"Accept": "application/xml"}, timeout=10)
     r.raise_for_status()
     if "xml" not in r.headers.get("Content-Type", ""):
         raise ValueError("Response is not XML")
@@ -135,7 +135,7 @@ def fetch_article_xml(boe_id: str) -> str:
     print(f"fetch_article_xml -> boe_id: {boe_id}")
     url = f"https://www.boe.es/diario_boe/xml.php?id={boe_id}"
     print(f"fetch_article_xml -> url: {url}")
-    r = requests.get(url)
+    r = session.get(url, timeout=10)
     r.raise_for_status()
     print("fetch_article_xml -> response size:", len(r.text))
     return r.text
@@ -167,7 +167,7 @@ def parse_article_xml(xml_text: str) -> dict:
 def fetch_article_text(url_xml: str) -> tuple[dict, list[str]]:
     """Download an article XML and return metadata and cleaned segments."""
     print(f"fetch_article_text -> url: {url_xml}")
-    r = requests.get(url_xml)
+    r = session.get(url_xml, timeout=10)
     r.raise_for_status()
     xml_text = r.text
     print("fetch_article_text -> downloaded", len(xml_text), "chars")

--- a/tasks/scraping.py
+++ b/tasks/scraping.py
@@ -1,10 +1,10 @@
 from prefect import task
-import requests
+from tasks import session
 from bs4 import BeautifulSoup
 
 
 @task
 def scrape_example_page(url: str) -> str:
-    response = requests.get(url)
+    response = session.get(url, timeout=10)
     soup = BeautifulSoup(response.text, "html.parser")
     return soup.get_text()

--- a/tests/tasks/test_boe.py
+++ b/tests/tasks/test_boe.py
@@ -11,7 +11,7 @@ from tasks.processing import clean_boe_text, split_into_paragraphs
 import requests
 
 
-@patch("tasks.boe.requests.get")
+@patch("tasks.boe.session.get")
 def test_fetch_index_xml_success(mock_get):
     mock_response = MagicMock()
     mock_response.text = "<xml>test data</xml>"
@@ -25,12 +25,13 @@ def test_fetch_index_xml_success(mock_get):
     mock_get.assert_called_once_with(
         f"https://www.boe.es/datosabiertos/api/boe/sumario/{year}{month}{day}",
         headers={"Accept": "application/xml"},
+        timeout=10,
     )
     mock_response.raise_for_status.assert_called_once()
     assert result == "<xml>test data</xml>"
 
 
-@patch("tasks.boe.requests.get")
+@patch("tasks.boe.session.get")
 def test_fetch_index_xml_success_with_capture(mock_get, capsys):
     mock_response = MagicMock()
     mock_response.text = "<xml>test data</xml>"
@@ -47,12 +48,13 @@ def test_fetch_index_xml_success_with_capture(mock_get, capsys):
     mock_get.assert_called_once_with(
         f"https://www.boe.es/datosabiertos/api/boe/sumario/{year}{month}{day}",
         headers={"Accept": "application/xml"},
+        timeout=10,
     )
     mock_response.raise_for_status.assert_called_once()
     assert result == "<xml>test data</xml>"
 
 
-@patch("tasks.boe.requests.get")
+@patch("tasks.boe.session.get")
 def test_fetch_index_xml_http_error(mock_get):
     mock_response = MagicMock()
     mock_response.headers = {"Content-Type": "application/xml"}
@@ -70,11 +72,12 @@ def test_fetch_index_xml_http_error(mock_get):
     mock_get.assert_called_once_with(
         f"https://www.boe.es/datosabiertos/api/boe/sumario/{year}{month}{day}",
         headers={"Accept": "application/xml"},
+        timeout=10,
     )
     mock_response.raise_for_status.assert_called_once()
 
 
-@patch("tasks.boe.requests.get")
+@patch("tasks.boe.session.get")
 def test_fetch_index_xml_invalid_content_type(mock_get):
     mock_response = MagicMock()
     mock_response.text = "<html>Not XML</html>"
@@ -163,7 +166,7 @@ def test_fetch_index_xml_by_date_invalid():
         fetch_index_xml_by_date.fn("202506")
 
 
-@patch("tasks.boe.requests.get")
+@patch("tasks.boe.session.get")
 def test_fetch_article_text_success(mock_get):
     sample_xml = """
     <documento>
@@ -181,7 +184,7 @@ def test_fetch_article_text_success(mock_get):
     url = "http://example.com/test.xml"
     metadata, segments = fetch_article_text.fn(url)
 
-    mock_get.assert_called_once_with(url)
+    mock_get.assert_called_once_with(url, timeout=10)
     mock_response.raise_for_status.assert_called_once()
     assert metadata == {
         "title": "Titulo de prueba",
@@ -191,7 +194,7 @@ def test_fetch_article_text_success(mock_get):
     assert segments == ["Cuerpo del texto"]
 
 
-@patch("tasks.boe.requests.get")
+@patch("tasks.boe.session.get")
 def test_fetch_article_text_http_error(mock_get):
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock(
@@ -202,7 +205,7 @@ def test_fetch_article_text_http_error(mock_get):
     with pytest.raises(requests.exceptions.HTTPError, match="Network Error"):
         fetch_article_text.fn("http://example.com/test.xml")
 
-    mock_get.assert_called_once_with("http://example.com/test.xml")
+    mock_get.assert_called_once_with("http://example.com/test.xml", timeout=10)
     mock_response.raise_for_status.assert_called_once()
 
 

--- a/tests/tasks/test_scraping.py
+++ b/tests/tasks/test_scraping.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 from tasks.scraping import scrape_example_page
 import requests
 
-@patch('tasks.scraping.requests.get')
+@patch('tasks.scraping.session.get')
 def test_scrape_example_page_success(mock_get):
     mock_response = MagicMock()
     mock_response.text = "<html><head><title>Test Page</title></head><body><p>Hello World!</p></body></html>"
@@ -12,11 +12,11 @@ def test_scrape_example_page_success(mock_get):
     url = "http://example.com"
     result = scrape_example_page.fn(url)
 
-    mock_get.assert_called_once_with(url)
+    mock_get.assert_called_once_with(url, timeout=10)
     assert "Hello World!" in result
     assert "Test Page" in result # Title is also text
 
-@patch('tasks.scraping.requests.get')
+@patch('tasks.scraping.session.get')
 def test_scrape_example_page_http_error(mock_get):
     mock_response = MagicMock()
     # It's good practice to ensure your mock raises an error if the code is expected to handle it.
@@ -30,4 +30,4 @@ def test_scrape_example_page_http_error(mock_get):
     with pytest.raises(requests.exceptions.RequestException, match="Test Network Error"):
         scrape_example_page.fn(url)
 
-    mock_get.assert_called_once_with(url)
+    mock_get.assert_called_once_with(url, timeout=10)


### PR DESCRIPTION
## Summary
- configure a shared retry-enabled `requests.Session`
- use it across BOE tasks and scraping tasks with a 10s timeout
- adjust tests to mock the new session interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb5aec3b4832d9b67fb3d0eefa898