### PR TITLE
Add optional date argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ There are two main ways to run the flows:
    ```bash
    python main.py
    ```
+   To use a custom date:
+   ```bash
+   python main.py --date 2024/12/31
+   ```
    You can modify `main.py` to run other flows or change parameters.
 
    **Note about `PREFECT_API_URL`:**

--- a/main.py
+++ b/main.py
@@ -1,7 +1,19 @@
 from flows.scrape_and_store import scrape_and_store
 from flows.scrape_boe_day_metadata import scrape_boe_day_metadata
+import argparse
 
-if __name__ == "__main__":
+DEFAULT_DATE = "2025/06/28"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run BOE scraping flows")
+    parser.add_argument(
+        "--date",
+        default=DEFAULT_DATE,
+        help="Date in YYYY/MM/DD format for scrape_boe_day_metadata",
+    )
+    args = parser.parse_args()
+
     # Test run for scrape and store all articles
     # scrape_and_store(
     #     url="https://www.boe.es/diario_boe/xml.php?id=BOE-A-2025-13297",
@@ -9,4 +21,8 @@ if __name__ == "__main__":
     # )
 
     # Test run for scape and process a day articles
-    scrape_boe_day_metadata("2025/06/28")
+    scrape_boe_day_metadata(args.date)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- parse optional `--date` argument in `main.py`
- show example of using `--date` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cda00a994832dbf745d841d7c8a9d