### PR TITLE
Handle missing index gracefully

### DIFF
--- a/flows/scrape_boe_day_metadata.py
+++ b/flows/scrape_boe_day_metadata.py
@@ -24,6 +24,9 @@ def scrape_boe_day_metadata(url_date_str: str = "2025/07/03"):
     init_db()
 
     index_boes = fetch_index_xml(year, month, day)
+    if not index_boes:
+        print("No existe \u00edndice para la fecha indicada.")
+        return
     boe_ids = extract_article_ids(index_boes)
     print(f"Art\u00edculos encontrados: {len(boe_ids)}")
 

--- a/tests/flows/test_scrape_boe_day_metadata.py
+++ b/tests/flows/test_scrape_boe_day_metadata.py
@@ -120,3 +120,34 @@ def test_scrape_boe_day_metadata_flow_no_ids(
     mock_fetch_article_xml.assert_not_called()
     mock_parse_article_xml.assert_not_called()
     mock_insert_article.assert_not_called()
+
+
+@patch("flows.scrape_boe_day_metadata.init_db")
+@patch("flows.scrape_boe_day_metadata.insert_article")
+@patch("flows.scrape_boe_day_metadata.parse_article_xml")
+@patch("flows.scrape_boe_day_metadata.fetch_article_xml")
+@patch("flows.scrape_boe_day_metadata.article_exists")
+@patch("flows.scrape_boe_day_metadata.get_article_metadata")
+@patch("flows.scrape_boe_day_metadata.extract_article_ids")
+@patch("flows.scrape_boe_day_metadata.fetch_index_xml")
+def test_scrape_boe_day_metadata_flow_no_index(
+    mock_fetch_index_xml,
+    mock_extract_article_ids,
+    mock_get_article_metadata,
+    mock_article_exists,
+    mock_fetch_article_xml,
+    mock_parse_article_xml,
+    mock_insert_article,
+    mock_init_db,
+):
+    mock_fetch_index_xml.return_value = ""
+
+    scrape_boe_day_metadata.fn(url_date_str="2023/01/03")
+
+    mock_fetch_index_xml.assert_called_once()
+    mock_extract_article_ids.assert_not_called()
+    mock_get_article_metadata.assert_not_called()
+    mock_article_exists.assert_not_called()
+    mock_fetch_article_xml.assert_not_called()
+    mock_parse_article_xml.assert_not_called()
+    mock_insert_article.assert_not_called()

--- a/tests/tasks/test_boe.py
+++ b/tests/tasks/test_boe.py
@@ -78,6 +78,26 @@ def test_fetch_index_xml_http_error(mock_get):
 
 
 @patch("tasks.boe.session.get")
+def test_fetch_index_xml_not_found(mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = ""
+    mock_response.headers = {"Content-Type": "application/xml"}
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    result = fetch_index_xml.fn("2023", "01", "02")
+
+    mock_get.assert_called_once_with(
+        "https://www.boe.es/datosabiertos/api/boe/sumario/20230102",
+        headers={"Accept": "application/xml"},
+        timeout=10,
+    )
+    mock_response.raise_for_status.assert_not_called()
+    assert result == ""
+
+
+@patch("tasks.boe.session.get")
 def test_fetch_index_xml_invalid_content_type(mock_get):
     mock_response = MagicMock()
     mock_response.text = "<html>Not XML</html>"


### PR DESCRIPTION
## Summary
- treat 404 responses in `fetch_index_xml`
- retry `fetch_index_xml` and `fetch_article_xml`
- exit flow early when daily index is missing
- add tests for missing index behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb3b8d584832dbc2d60e13667c91e